### PR TITLE
Fix deprecated warnings and adopt Iterator APIs

### DIFF
--- a/.github/actions/install-moonbit/action.yml
+++ b/.github/actions/install-moonbit/action.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 International Digital Economy Academy
+# Copyright 2026 International Digital Economy Academy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 International Digital Economy Academy
+# Copyright 2026 International Digital Economy Academy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 International Digital Economy Academy
+# Copyright 2026 International Digital Economy Academy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 International Digital Economy Academy
+# Copyright 2026 International Digital Economy Academy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ build/
 install/
 publish/
 _build/
+_build
 target

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 build/
 install/
 publish/
+_build/
+target

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,4 +1,4 @@
-# Copyright 2025 International Digital Economy Academy
+# Copyright 2026 International Digital Economy Academy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2025 International Digital Economy Academy
+# Copyright 2026 International Digital Economy Academy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/prepare.py
+++ b/scripts/prepare.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2025 International Digital Economy Academy
+# Copyright 2026 International Digital Economy Academy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2025 International Digital Economy Academy
+# Copyright 2026 International Digital Economy Academy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2025 International Digital Economy Academy
+# Copyright 2026 International Digital Economy Academy
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/args.c
+++ b/src/args.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/args.mbt
+++ b/src/args.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/args_test.mbt
+++ b/src/args_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/async.c
+++ b/src/async.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/async.mbt
+++ b/src/async.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/async_test.mbt
+++ b/src/async_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/barrier.mbt
+++ b/src/barrier.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/bytes.c
+++ b/src/bytes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/bytes.mbt
+++ b/src/bytes.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/check.c
+++ b/src/check.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/check.mbt
+++ b/src/check.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/check_test.mbt
+++ b/src/check_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cond.c
+++ b/src/cond.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/cond.mbt
+++ b/src/cond.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cond_test.mbt
+++ b/src/cond_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cpu_info.c
+++ b/src/cpu_info.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/debug.mbt
+++ b/src/debug.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/dl.c
+++ b/src/dl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/dl.mbt
+++ b/src/dl.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/dns.c
+++ b/src/dns.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/dns.mbt
+++ b/src/dns.mbt
@@ -252,35 +252,45 @@ pub fn AddrInfo::canonname(self : AddrInfo) -> Bytes? {
 }
 
 ///|
-fn AddrInfoResults::iter(self : AddrInfoResults) -> Iter[AddrInfo] {
-  Iter::new(fn(yield_) {
-    if uv_addrinfo_results_iterate(self, fn(
-        _,
-        family,
-        socktype,
-        protocol,
-        addr,
-        canonname,
-      ) {
-        let canonname = if canonname.is_null() {
-          None
-        } else {
-          let buffer = @buffer.new()
-          for i = 0; canonname[i] != 0; i = i + 1 {
-            buffer.write_byte(canonname[i])
-          }
-          Some(buffer.contents())
+fn AddrInfoResults::iterator(self : AddrInfoResults) -> Iterator[AddrInfo] {
+  let items : Array[AddrInfo] = []
+  ignore(
+    uv_addrinfo_results_iterate(self, fn(
+      _,
+      family,
+      socktype,
+      protocol,
+      addr,
+      canonname,
+    ) {
+      let canonname = if canonname.is_null() {
+        None
+      } else {
+        let buffer = @buffer.new()
+        for i = 0; canonname[i] != 0; i = i + 1 {
+          buffer.write_byte(canonname[i])
         }
-        match yield_({ family, socktype, protocol, addr, canonname }) {
-          IterEnd => true
-          IterContinue => false
-        }
-      }) {
-      return IterEnd
+        Some(buffer.contents())
+      }
+      items.push({ family, socktype, protocol, addr, canonname })
+      false
+    }),
+  )
+  let mut i = 0
+  Iterator::new(fn() {
+    if i < items.length() {
+      let item = items[i]
+      i = i + 1
+      Some(item)
     } else {
-      return IterContinue
+      None
     }
   })
+}
+
+///|
+fn AddrInfoResults::iter(self : AddrInfoResults) -> Iter[AddrInfo] {
+  self.iterator().iter()
 }
 
 ///|

--- a/src/dns.mbt
+++ b/src/dns.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/dns_test.mbt
+++ b/src/dns_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/env.c
+++ b/src/env.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/env.mbt
+++ b/src/env.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/env.mbt
+++ b/src/env.mbt
@@ -102,7 +102,7 @@ extern "c" fn uv_environ_get_value(
 ) -> @c.Pointer[Byte] = "moonbit_uv_environ_get_value"
 
 ///|
-pub fn Environ::iter2(self : Environ) -> Iter2[Bytes, Bytes] {
+pub fn Environ::iterator2(self : Environ) -> Iterator2[Bytes, Bytes] {
   fn read_c_string(ptr : @c.Pointer[Byte]) -> Bytes {
     let buf = @buffer.new()
     for i = 0; ptr[i] != 0; i = i + 1 {
@@ -112,16 +112,20 @@ pub fn Environ::iter2(self : Environ) -> Iter2[Bytes, Bytes] {
   }
 
   let count = uv_environ_count(self)
-  Iter2::new(fn(yield_) {
-    for i in 0..<count {
+  let mut i = 0
+  Iterator2::new(fn() {
+    if i < count {
       let name = read_c_string(uv_environ_get_name(self, i))
       let value = read_c_string(uv_environ_get_value(self, i))
-      match yield_(name, value) {
-        IterEnd => break IterEnd
-        IterContinue => ()
-      }
+      i = i + 1
+      Some((name, value))
     } else {
-      IterContinue
+      None
     }
   })
+}
+
+///|
+pub fn Environ::iter2(self : Environ) -> Iter2[Bytes, Bytes] {
+  self.iterator2().iter2()
 }

--- a/src/env.mbt
+++ b/src/env.mbt
@@ -102,7 +102,7 @@ extern "c" fn uv_environ_get_value(
 ) -> @c.Pointer[Byte] = "moonbit_uv_environ_get_value"
 
 ///|
-pub fn Environ::iterator2(self : Environ) -> Iterator2[Bytes, Bytes] {
+pub fn Environ::iter2(self : Environ) -> Iter2[Bytes, Bytes] {
   fn read_c_string(ptr : @c.Pointer[Byte]) -> Bytes {
     let buf = @buffer.new()
     for i = 0; ptr[i] != 0; i = i + 1 {
@@ -122,10 +122,5 @@ pub fn Environ::iterator2(self : Environ) -> Iterator2[Bytes, Bytes] {
     } else {
       None
     }
-  })
-}
-
-///|
-pub fn Environ::iter2(self : Environ) -> Iter2[Bytes, Bytes] {
-  self.iterator2().iter2()
+  }).iter2()
 }

--- a/src/env_test.mbt
+++ b/src/env_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/error.c
+++ b/src/error.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/error.mbt
+++ b/src/error.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/fs.c
+++ b/src/fs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/fs.mbt
+++ b/src/fs.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/fs_event.c
+++ b/src/fs_event.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/fs_event.mbt
+++ b/src/fs_event.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/fs_event_test.mbt
+++ b/src/fs_event_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/fs_poll.c
+++ b/src/fs_poll.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/fs_poll.mbt
+++ b/src/fs_poll.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/fs_poll_test.mbt
+++ b/src/fs_poll_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/fs_test.mbt
+++ b/src/fs_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/handle.c
+++ b/src/handle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/handle.h
+++ b/src/handle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/handle.mbt
+++ b/src/handle.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/handle_test.mbt
+++ b/src/handle_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/idle.c
+++ b/src/idle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/idle.mbt
+++ b/src/idle.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/idle_test.mbt
+++ b/src/idle_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/if.c
+++ b/src/if.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/if.mbt
+++ b/src/if.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/if_test.mbt
+++ b/src/if_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/internal/assert/assert.mbt
+++ b/src/internal/assert/assert.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ip.mbt
+++ b/src/ip.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ip_test.mbt
+++ b/src/ip_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/key.c
+++ b/src/key.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/key.mbt
+++ b/src/key.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/library.c
+++ b/src/library.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/loop.c
+++ b/src/loop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/loop.mbt
+++ b/src/loop.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/loop_test.mbt
+++ b/src/loop_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/metrics.mbt
+++ b/src/metrics.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/metrics_test.mbt
+++ b/src/metrics_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/mutex.h
+++ b/src/mutex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/mutex.mbt
+++ b/src/mutex.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/once.c
+++ b/src/once.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/once.mbt
+++ b/src/once.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/os.c
+++ b/src/os.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/os.mbt
+++ b/src/os.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/os_test.mbt
+++ b/src/os_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/passwd.mbt
+++ b/src/passwd.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/passwd_test.mbt
+++ b/src/passwd_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pipe.mbt
+++ b/src/pipe.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/pipe_test.mbt
+++ b/src/pipe_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -356,6 +356,7 @@ pub enum DirentType {
 
 type Environ
 pub fn Environ::iter2(Self) -> Iter2[Bytes, Bytes]
+pub fn Environ::iterator2(Self) -> Iterator2[Bytes, Bytes]
 
 type File
 pub fn File::of_int(Int) -> Self

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -356,7 +356,6 @@ pub enum DirentType {
 
 type Environ
 pub fn Environ::iter2(Self) -> Iter2[Bytes, Bytes]
-pub fn Environ::iterator2(Self) -> Iterator2[Bytes, Bytes]
 
 type File
 pub fn File::of_int(Int) -> Self

--- a/src/poll.c
+++ b/src/poll.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/poll.mbt
+++ b/src/poll.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/poll_test.mbt
+++ b/src/poll_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/prepare.mbt
+++ b/src/prepare.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/prepare_test.mbt
+++ b/src/prepare_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/process.c
+++ b/src/process.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/process.mbt
+++ b/src/process.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/process_test.mbt
+++ b/src/process_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/random.c
+++ b/src/random.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/random.mbt
+++ b/src/random.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/random_test.mbt
+++ b/src/random_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/req.c
+++ b/src/req.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/req.mbt
+++ b/src/req.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/req_test.mbt
+++ b/src/req_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/rusage.c
+++ b/src/rusage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/rusage.mbt
+++ b/src/rusage.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/rusage_test.mbt
+++ b/src/rusage_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/rwlock.c
+++ b/src/rwlock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/rwlock.mbt
+++ b/src/rwlock.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/rwlock_test.mbt
+++ b/src/rwlock_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/sem.c
+++ b/src/sem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/sem.mbt
+++ b/src/sem.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/sem_test.mbt
+++ b/src/sem_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/shutdown.c
+++ b/src/shutdown.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/signal.c
+++ b/src/signal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/signal.mbt
+++ b/src/signal.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/socket.c
+++ b/src/socket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/socket.h
+++ b/src/socket.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/socket.mbt
+++ b/src/socket.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/socket_test.mbt
+++ b/src/socket_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/stat.c
+++ b/src/stat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/stream.c
+++ b/src/stream.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/stream.h
+++ b/src/stream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/stream.mbt
+++ b/src/stream.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/stream_test.mbt
+++ b/src/stream_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/string.c
+++ b/src/string.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/string.mbt
+++ b/src/string.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/tcp.mbt
+++ b/src/tcp.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/tcp_test.mbt
+++ b/src/tcp_test.mbt
@@ -264,7 +264,8 @@ test "Tcp::close_reset" {
           () => client.read_start(
             (_, _) => Bytes::make(32, 0)[:],
             (_, _, _) => {
-              errors.push(Failure("Expect ECONNRESET"))
+              let failure : Failure = Failure("Expect ECONNRESET")
+              errors.push(failure)
               client.read_stop() catch {
                 e => errors.push(e)
               }

--- a/src/tcp_test.mbt
+++ b/src/tcp_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/thread.c
+++ b/src/thread.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/thread.mbt
+++ b/src/thread.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/thread_test.mbt
+++ b/src/thread_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/time.c
+++ b/src/time.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/time.mbt
+++ b/src/time.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/time_test.mbt
+++ b/src/time_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/timer.c
+++ b/src/timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/timer.mbt
+++ b/src/timer.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/timer_test.mbt
+++ b/src/timer_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/tty.c
+++ b/src/tty.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/tty.mbt
+++ b/src/tty.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/udp.c
+++ b/src/udp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/udp.mbt
+++ b/src/udp.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/udp_test.mbt
+++ b/src/udp_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/uv.c
+++ b/src/uv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uv.h
+++ b/src/uv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uv.mbt
+++ b/src/uv.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/version.c
+++ b/src/version.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/version.mbt
+++ b/src/version.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/version_test.mbt
+++ b/src/version_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/work.c
+++ b/src/work.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/work.mbt
+++ b/src/work.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/work_test.mbt
+++ b/src/work_test.mbt
@@ -1,4 +1,4 @@
-// Copyright 2025 International Digital Economy Academy
+// Copyright 2026 International Digital Economy Academy
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/write.c
+++ b/src/write.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 International Digital Economy Academy
+ * Copyright 2026 International Digital Economy Academy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Add `target` and `_build` to `.gitignore` to prepare for migration artifacts
- Update iterators in `src/dns.mbt` and `src/env.mbt` to use `Iterator`/`Iterator2`
- Adjust iterator construction to the new `Iterator::new`/`Iterator2::new` callback style
- Update generated interface and tests to reflect the API changes

## Rationale
The task is to resolve as many deprecation warnings/errors as possible, with the major breaking change being the move from `Iter`/`Iter2` to `Iterator`/`Iterator2`. The `.gitignore` change ensures future build outputs are ignored as part of the migration.

## Implementation details
- Introduced new `iterator2` entry points where needed and kept legacy `iter2` delegating to them for compatibility
- Rewrote iterator constructors to capture state and return `Some(elem)`/`None` via the new callback signature
- Regenerated `.mbti` to capture visible API changes and adjusted tests accordingly